### PR TITLE
Support fluentd version 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .ruby-version
+/vendor/bundle

--- a/lib/fluent/plugin/in_sendgrid_event.rb
+++ b/lib/fluent/plugin/in_sendgrid_event.rb
@@ -18,6 +18,10 @@ module Fluent
     unless method_defined?(:log)
       define_method("log") { $log }
     end
+  
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
 
     def initialize
       super
@@ -101,7 +105,7 @@ module Fluent
 
     def emit_event(event)
       log.trace "in_sendgrid_event: emit_event"
-      Engine.emit("#{tag}", Engine.now, event)
+      router.emit("#{tag}", router.now, event)
     end
   end
 end

--- a/lib/fluent/plugin/in_sendgrid_event.rb
+++ b/lib/fluent/plugin/in_sendgrid_event.rb
@@ -105,7 +105,7 @@ module Fluent
 
     def emit_event(event)
       log.trace "in_sendgrid_event: emit_event"
-      router.emit("#{tag}", router.now, event)
+      router.emit("#{tag}", Fluent::EventTime.now, event)
     end
   end
 end


### PR DESCRIPTION
Fix error to use this plugin with fluentd version 1.11.
Please check this update whenever you have time ;)

Errors

```
fluent.warn: {"message":"in_sendgrid_event: Retry: Reason: BUG: use router.emit instead of Engine.emit"}
```

```
fluent.warn: {"message":"in_sendgrid_event: Retry: Reason: undefined method `now' for #<Fluent::EventRouter:0x00007f97631559d0>"}
```

Gemfile.lock

```
PATH
  remote: .
  specs:
    fluent-plugin-sendgrid-event (0.0.5)
      fluentd

GEM
  remote: https://rubygems.org/
  specs:
    concurrent-ruby (1.1.7)
    cool.io (1.7.0)
    fluentd (1.11.4)
      cool.io (>= 1.4.5, < 2.0.0)
      http_parser.rb (>= 0.5.1, < 0.7.0)
      msgpack (>= 1.3.1, < 2.0.0)
      serverengine (>= 2.0.4, < 3.0.0)
      sigdump (~> 0.2.2)
      strptime (>= 0.2.2, < 1.0.0)
      tzinfo (>= 1.0, < 3.0)
      tzinfo-data (~> 1.0)
      yajl-ruby (~> 1.0)
    http_parser.rb (0.6.0)
    msgpack (1.3.3)
    power_assert (1.2.0)
    rake (10.5.0)
    serverengine (2.2.1)
      sigdump (~> 0.2.2)
    sigdump (0.2.4)
    strptime (0.2.5)
    test-unit (3.3.6)
      power_assert
    tzinfo (2.0.2)
      concurrent-ruby (~> 1.0)
    tzinfo-data (1.2020.4)
      tzinfo (>= 1.0.0)
    yajl-ruby (1.4.1)

PLATFORMS
  ruby

DEPENDENCIES
  bundler (~> 1.10)
  fluent-plugin-sendgrid-event!
  rake (~> 10.0)
  test-unit

BUNDLED WITH
   1.17.2
```

Test Rresult

```
> bundle exec rake test                           
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I"lib:lib:test" -I"/Users/c-fukuda/ghq/github.com/fnaoto/fluent-plugin-sendgrid-event/vendor/bundle/ruby/2.6.0/gems/rake-10.5.0/lib" "/Users/c-fukuda/ghq/github.com/fnaoto/fluent-plugin-sendgrid-event/vendor/bundle/ruby/2.6.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/**/test_*.rb" 
Loaded suite /Users/c-fukuda/ghq/github.com/fnaoto/fluent-plugin-sendgrid-event/vendor/bundle/ruby/2.6.0/gems/rake-10.5.0/lib/rake/rake_test_loader
Started
[2020-11-11 15:53:03] INFO  WEBrick 1.4.2
[2020-11-11 15:53:03] INFO  ruby 2.6.3 (2019-04-16) [universal.x86_64-darwin19]
[2020-11-11 15:53:03] INFO  WEBrick::HTTPServer#start: pid=61648 port=9191
.127.0.0.1 - auth_user [11/Nov/2020:15:53:03 JST] "POST / HTTP/1.1" 200 0
- -> /
[2020-11-11 15:53:04] INFO  WEBrick 1.4.2
[2020-11-11 15:53:04] INFO  ruby 2.6.3 (2019-04-16) [universal.x86_64-darwin19]
[2020-11-11 15:53:04] INFO  WEBrick::HTTPServer#start: pid=61648 port=9191
[2020-11-11 15:53:04] ERROR WEBrick::HTTPStatus::Unauthorized
.[2020-11-11 15:53:04] INFO  going to shutdown ...
..127.0.0.1 - - [11/Nov/2020:15:53:04 JST] "POST / HTTP/1.1" 401 309
- -> /
[2020-11-11 15:53:04] INFO  WEBrick 1.4.2
[2020-11-11 15:53:04] INFO  ruby 2.6.3 (2019-04-16) [universal.x86_64-darwin19]
[2020-11-11 15:53:04] INFO  WEBrick::HTTPServer#start done.
[2020-11-11 15:53:04] INFO  WEBrick::HTTPServer#start: pid=61648 port=9191
.[2020-11-11 15:53:05] INFO  going to shutdown ...
127.0.0.1 - - [11/Nov/2020:15:53:05 JST] "POST / HTTP/1.1" 400 0
- -> /
[2020-11-11 15:53:05] INFO  WEBrick::HTTPServer#start done.
[2020-11-11 15:53:05] INFO  WEBrick 1.4.2
[2020-11-11 15:53:05] INFO  ruby 2.6.3 (2019-04-16) [universal.x86_64-darwin19]
[2020-11-11 15:53:05] INFO  WEBrick::HTTPServer#start: pid=61648 port=9191
.
Finished in 3.676566 seconds.
----------------------------------------------------------------------------------------------------
6 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------
1.63 tests/s, 14.14 assertions/s
```